### PR TITLE
Add movie collection images and artistic tile display

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,53 @@ Live app: https://movie-kombat.vercel.app/
 
 - Search movies with TMDB (single title or bulk list mode).
 - Discover movies with TMDB by genre, streaming provider, and country.
+- Load ready-made local movie collections from markdown files in `movies/`.
 - Smart poster handling (fallback placeholders when posters are missing).
 - Blind mode to hide posters and vote by title.
 - Interactive bracket visualization through each kombat stage.
 - Final winner screen with IMDb link.
+
+## Local movie collections
+
+You can add your own collection tiles shown in the app by creating markdown files inside the root `movies/` folder.
+
+Rules:
+
+- Create one `.md` file per collection in `movies/`.
+- Use a first-level heading (`#`) as the collection title.
+- Add movie titles as bullet points (one title per line).
+- Optional: include an HTML image tag to use a custom tile image.
+- Keep at least 16 movie titles so the app can build a 16-movie kombat selection.
+
+Example (`movies/my-collection.md`):
+
+```md
+# My Collection
+<img src="https://example.com/my-image.jpg" alt="my collection" />
+
+* Movie Title 1
+* Movie Title 2
+* Movie Title 3
+* Movie Title 4
+* Movie Title 5
+* Movie Title 6
+* Movie Title 7
+* Movie Title 8
+* Movie Title 9
+* Movie Title 10
+* Movie Title 11
+* Movie Title 12
+* Movie Title 13
+* Movie Title 14
+* Movie Title 15
+* Movie Title 16
+```
+
+Notes:
+
+- File name becomes the internal collection id.
+- The app ignores `movies/README.md`.
+- Duplicate titles are automatically deduplicated (case-insensitive).
 
 ## Kombat rules
 

--- a/movies/2000s-horror.md
+++ b/movies/2000s-horror.md
@@ -1,5 +1,5 @@
 # 2000s Horror
-<img width="935" height="619" alt="tarantino" src="https://github.com/user-attachments/assets/51305a43-deb8-4df4-b8e2-baf3e7f7bab3" />
+<img width="648" height="751" alt="horror" src="https://github.com/user-attachments/assets/af597082-0fff-4f4e-a2eb-d33a5ede1ac4" />
 
 * 28 Days Later
 * The Ring

--- a/movies/2000s-horror.md
+++ b/movies/2000s-horror.md
@@ -1,4 +1,5 @@
 # 2000s Horror
+<img width="935" height="619" alt="tarantino" src="https://github.com/user-attachments/assets/51305a43-deb8-4df4-b8e2-baf3e7f7bab3" />
 * 28 Days Later
 * The Ring
 * The Others

--- a/movies/2000s-horror.md
+++ b/movies/2000s-horror.md
@@ -1,0 +1,21 @@
+# 2000s Horror
+* 28 Days Later
+* The Ring
+* The Others
+* Saw
+* Let the Right One In
+* The Descent
+* Pan's Labyrinth
+* Paranormal Activity
+* [Rec]
+* Hostel
+* The Orphanage
+* Shaun of the Dead
+* The Mist
+* Drag Me to Hell
+* The Strangers
+* American Psycho
+* Ginger Snaps
+* Trick 'r Treat
+* Cloverfield
+* Martyrs

--- a/movies/2000s-horror.md
+++ b/movies/2000s-horror.md
@@ -1,5 +1,6 @@
 # 2000s Horror
 <img width="935" height="619" alt="tarantino" src="https://github.com/user-attachments/assets/51305a43-deb8-4df4-b8e2-baf3e7f7bab3" />
+
 * 28 Days Later
 * The Ring
 * The Others

--- a/movies/buddy-films.md
+++ b/movies/buddy-films.md
@@ -1,4 +1,5 @@
 # Buddy films
+<img width="700" height="533" alt="buddy" src="https://github.com/user-attachments/assets/f96278f4-6334-4424-883a-fcc771a354e1" />
 
 * Men in Black (MIB) 
 * Lethal Weapon 

--- a/movies/buddy-films.md
+++ b/movies/buddy-films.md
@@ -1,0 +1,52 @@
+# Buddy films
+
+* Men in Black (MIB) 
+* Lethal Weapon 
+* Sherlock Holmes 
+* Léon: The Professional 
+* Marshland 
+* Training Day 
+* Last Action Hero 
+* Bad Boys 
+* Green Book 
+* Lethal Weapon 2 
+* Lethal Weapon 3 
+* Sherlock Holmes: A Game of Shadows (Sherlock Holmes 2) 
+* Lethal Weapon 4 
+* Men in Black 2 
+* Die Hard with a Vengeance 
+* Butch Cassidy and the Sundance Kid 
+* The Last Boy Scout 
+* Men in Black 3 
+* Zootropolis 
+* Wild Wild West 
+* Hell or High Water 
+* Hot Fuzz 
+* The Man From U.N.C.L.E. 
+* Bad Boys II 
+* The Magnificent Seven 
+* The Nice Guys 
+* Beverly Hills Cop 
+* 21 Jump Street 
+* 16 Blocks (Sixteen Blocks) 
+* Miami Vice 
+* The Magnificent Seven 
+* Tango & Cash 
+* Rush Hour 
+* Kiss Kiss Bang Bang 
+* 2 Guns 
+* Bright 
+* Starsky & Hutch 
+* White Chicks 
+* 22 Jump Street 
+* Beverly Hills Cop II 
+* El Dorado 
+* Bulletproof Monk 
+* Turner & Hooch 
+* The Guard 
+* Red Heat 
+* White Men Can't Jump 
+* Rush Hour 2 
+* White House Down 
+* Black Rain 
+* Beverly Hills Cop III 

--- a/movies/my-list.md
+++ b/movies/my-list.md
@@ -4,7 +4,6 @@
 * Desaparecidos
 * Memoirs of an Invisible Man
 * The Wild Robot
-* Molt lluny
 * Kika
 * Dangerous Minds
 * Dark Waters
@@ -220,7 +219,6 @@
 * Eight Legged Freaks
 * Te estoy amando locamente
 * The Emerald Forest
-* Arny. Historia de una infamia
 * Absolute Power
 * Passenger 57
 * Crimson Tide
@@ -292,7 +290,6 @@
 * Stay
 * Heartbreakers
 * Bastarden
-* Flow
 * Fausto 5.0 (Faust 5.0)
 * The Omen
 * Escape Room
@@ -314,7 +311,6 @@
 * Jacob’s Ladder
 * Love Story
 * Meet the Spartans
-* CSI Las Vegas: Grave Danger
 * Firestorm
 * 10 Things I Hate about You
 * Thief (Violent Streets)

--- a/movies/my-list.md
+++ b/movies/my-list.md
@@ -1,4 +1,6 @@
 # Creator's watchlist
+<img width="831" height="870" alt="movie-kombat-logo" src="https://github.com/user-attachments/assets/f50eec7a-a3b4-4f99-8797-37786bc8dc39" />
+
 * Desaparecidos
 * Memoirs of an Invisible Man
 * The Wild Robot

--- a/movies/my-list.md
+++ b/movies/my-list.md
@@ -40,7 +40,7 @@
 * The 6th Day
 * Rapito
 * Midnight Run
-* John Carpenter’s Ghosts of Marsaka
+* Ghosts of Mars
 * First Reformed
 * Before the Devil Knows You’re Dead
 * Innerspace
@@ -95,7 +95,6 @@
 * American Hustle
 * Jack London’s White Fang
 * ¡Hay motivo!
-* Citas Barcelona
 * Jujutsu Kaisen
 * Upon Entry
 * House of Sand and Fog

--- a/movies/my-list.md
+++ b/movies/my-list.md
@@ -1,0 +1,417 @@
+# Creator's watchlist
+* Desaparecidos
+* Memoirs of an Invisible Man
+* The Wild Robot
+* Molt lluny
+* Kika
+* Dangerous Minds
+* Dark Waters
+* Adiós
+* The Rite
+* Greyhound
+* Heavy
+* Bells of St. Mary’s
+* Días mejores
+* Hidden Figures
+* The Uninvited Guest
+* Memories
+* Non-Stop
+* Megalopolis
+* Scream
+* Logan
+* The Right Stuff
+* The Three Musketeers
+* El abuelo
+* Amaro Glory Road
+* Missing
+* Session 9
+* Nuit blanche
+* Ex Machina
+* Anatomie d’une chute
+* Cidade de Deus
+* Blade
+* Ferris Bueller’s Day Off
+* Point Break
+* All of Us Strangers
+* Frenzy
+* Infamous
+* The 6th Day
+* Rapito
+* Midnight Run
+* John Carpenter’s Ghosts of Marsaka
+* First Reformed
+* Before the Devil Knows You’re Dead
+* Innerspace
+* The Hole
+* Te doy mis ojos
+* Extremely Loud and Incredibly Close
+* What We Do in the Shadows
+* Lost in Space
+* Maestro
+* El arte de morir
+* Oppenheimer
+* The Perks of Being a Wallflower
+* Passion of Mind
+* Now You See Me
+* Stigmata
+* North
+* The Killer
+* Stand by Me
+* Caddyshack
+* The Kite Runner
+* Born on the Fourth of July
+* 1883
+* Cyrano de Bergerac
+* La virgen roja
+* Carol
+* El Club
+* A Man Called Otto
+* The Killing of a Sacred Deer
+* Elegy
+* The Fourth Kin
+* Lights Out
+* Cop Land
+* Boże Ciało
+* El bola
+* A Quiet Place: Day One
+* La novia
+* Lost & Found
+* Boys Don’t Cry
+* Spaceman
+* Chinas
+* Martín (Hache)
+* The Fall Guy
+* Joy Ride
+* Lost Highway
+* The Mexican
+* Dracula 2000
+* Kingdom of Heaven
+* Severance
+* At Eternity’s Gate
+* Dial M for Murder
+* Family Plot
+* American Hustle
+* Jack London’s White Fang
+* ¡Hay motivo!
+* Citas Barcelona
+* Jujutsu Kaisen
+* Upon Entry
+* House of Sand and Fog
+* Kimitachi wa dô ikiru ka
+* Mamífera
+* The Way We Were
+* Mientras duermes
+* Mama
+* Mercury Rising
+* Juror #2
+* Revenge
+* Ju-on
+* Monster
+* The Lake House
+* The Danish Girl
+* Bless the Child
+* My Old Ass
+* Saben aquell
+* Stir of Echoes
+* Fresa y chocolate
+* Le pacte des loups
+* Tropa de Elite
+* M3GAN
+* Hola, ¿estás sola?
+* Stealth
+* The Apprentice
+* Coach Carter
+* Soy Nevenka
+* Lost in Translation
+* National Lampoon’s Vacation
+* Talk to Me
+* The Wolverine
+* The Power of the Dog
+* Kuolleet Lehdet
+* The Assessment
+* Demolition Man
+* Longlegs
+* In the Heart of the Sea
+* U.S. Marshals
+* Cuando llega la noche
+* Urban Legend
+* The Conjuring
+* Paranormal Activity 2
+* Ich seh, Ich seh
+* Being John Malkovich
+* Final Destination
+* Casino
+* Excalibur
+* I See You
+* Christopher Robin
+* Insidious
+* Fright Night
+* Much Ado About Nothing
+* Ghost Ship
+* El segundo nombre
+* Creep
+* Shutter
+* Horizon: An American Saga – Chapter 1
+* Under Suspicion
+* Firefox
+* Getting Away With Murder
+* Affliction
+* Psycho
+* Midway
+* Darkness
+* The Grudge
+* The Menu
+* Kairo
+* Frailty
+* Volveréis
+* The Last House on the Left
+* Hit Man
+* Driving Miss Daisy
+* Just Shoot Me!
+* Explorers
+* Hellraiser
+* Heist
+* Cry Macho
+* The Holdovers
+* Goya en Burdeos
+* The Prince of Tides
+* Tuno negro
+* The Invitation
+* Eyes Wide Shut
+* The Scarlet and the Black
+* Freedom Writers
+* Flores de otro mundo
+* Conan the Barbarian
+* Paradise Alley
+* Snakes on a Plane
+* Monster’s Ball
+* Spellbound
+* Youth – La giovinezza
+* The Fan
+* También la lluvia
+* Gothika
+* Parlement
+* Legend
+* High Life
+* The Postman
+* Asteroid City
+* Tango & Cash
+* Carne trémula
+* Noviembre
+* Valle de sombras
+* Killers of the Flower Moon
+* Robin Hood: Prince of Thieves
+* Los Borgia
+* Inside Man
+* Soundtrack to a Coup d’Etat
+* The Cell
+* Wings
+* Identity
+* Jack
+* La cueva
+* Southern Comfort
+* X
+* Insidious: Chapter 2
+* Hodejegerne
+* Cabin Fever
+* Walk the Line
+* Eight Legged Freaks
+* Te estoy amando locamente
+* The Emerald Forest
+* Arny. Historia de una infamia
+* Absolute Power
+* Passenger 57
+* Crimson Tide
+* Crimson Peak
+* Devil
+* Runaway Jury
+* Superman II
+* Blue Ruin
+* Unfriended
+* Sunshine
+* The Astronaut’s Wife
+* Wayne’s World
+* Grown Ups
+* Enemy of the State
+* Hot Shots!
+* L.A. Confidential
+* Before Night Falls
+* Perfect Days
+* La Marche de l’empereur
+* 48 Hrs.
+* Creatura
+* A Beautiful Day in the Neighborhood
+* La boda de Rosa
+* Blues Brothers 2000
+* Ladyhawke
+* From
+* On the Basis of Sex
+* The Last Boy Scout
+* Boîte noire
+* The People vs. Larry Flynt
+* Rememory
+* Europa Report
+* Beautiful Girls
+* Vertigo
+* Dogville
+* The Mothman Prophecies
+* 3:10 to Yuma
+* Coneheads
+* Memphis Belle
+* Gin gwai (Jian gui) (The Eye)
+* The Bikeriders
+* May December
+* The Spirit of St. Louis
+* Nuovo Cinema Paradiso
+* First Man
+* I’ll Do Anything
+* Striptease
+* Sicario
+* Vegas
+* La habitación de al lado
+* Cigarette Burns (Masters of Horror Series)
+* Malignant
+* The Man Who Knew Too Much
+* Knight and Day
+* Thank You For Smoking
+* Dream Scenario
+* The Killing
+* Busanhaeng
+* You’re Next
+* Death to Smoochy
+* Finch
+* Mars Attacks!
+* The Terminator
+* Payback
+* Lucía y el sexo
+* Honogurai mizu no sokokara (Dark Water)
+* State of Grace
+* Strangers on a Train
+* Stay
+* Heartbreakers
+* Bastarden
+* Flow
+* Fausto 5.0 (Faust 5.0)
+* The Omen
+* Escape Room
+* Idle Hands
+* Ghostland
+* The Last Witch Hunter
+* I’m Not There
+* Rapa Nui
+* La pelota vasca, la piel contra la piedra
+* Daniela Forever
+* Godsend
+* Premonition
+* Knight of Cups
+* 20,000 Leagues Under the Sea
+* La lengua de las mariposas
+* Duel in the Sun
+* George of the Jungle
+* Nomadland
+* Jacob’s Ladder
+* Love Story
+* Meet the Spartans
+* CSI Las Vegas: Grave Danger
+* Firestorm
+* 10 Things I Hate about You
+* Thief (Violent Streets)
+* What Lies Beneath
+* Body Double
+* Dheepan
+* The Fountainhead
+* Miss Pettigrew Lives for a Day
+* Bolt
+* Phantom of the Paradise
+* Papillon
+* Biutiful
+* Eden Lake
+* My Darling Clementine
+* Pitch Perfect
+* The Shrouds
+* Chasing Amy
+* National Treasure
+* The human voice
+* The Perks of Being a Wallflower
+* Fireproof
+* Entre les murs
+* The Adventures of Robin Hood
+* We Were Soldiers
+* Léon, El profesional
+* Sisters
+* Madagascar: Escape 2 Africa (Madagascar 2)
+* Jumper
+* Rushmore
+* Judgment at Nuremberg
+* Wuthering Heights
+* Fuera de carta
+* Brittany Runs a Marathon
+* The Day the Earth Stood Still
+* Indecent Proposal
+* Severance
+* The Getaway
+* Gods and Monsters
+* The Dark Knight
+* The Breakfast Club
+* Lost Highway
+* Yellowstone
+* Minuscule: La vallée des fourmis perdues (Minuscule: Valley of the Lost Ants)
+* Glory Road
+* What Happens In Vegas
+* Le Tout Nouveau Testament
+* Welcome to Marwen
+* Taken
+* Druk
+* Two Lovers
+* Romancing the Stone
+* Death Race
+* Bones and All
+* Manticora
+* Bardo, falsa crónica de unas cuantas verdades
+* Jack
+* Detachment
+* Raising Cain
+* The Rider
+* My Dog Skip
+* Here
+* This is Spinal Tap
+* Lolita
+* The Reader
+* Ainda estou aqui
+* CSI: Crime Scene Investigation – Las Vegas
+* The Wolverine (X-Men: Wolverine 2)
+* Gunfight at the OK Corral
+* Casualties of War
+* Soundtrack to a Coup d’Etat
+* Kingdom of Heaven
+* The Last Duel
+* Elephant
+* Adam’s Rib
+* Assassin’s Creed
+* Young Sherlock Holmes
+* Slumdog Millionaire
+* Prince of Persia: The Sands of Time
+* Real Women Have Curves
+* The Chronicles of Narnia: Prince Caspian
+* Dans la maison
+* The Holdovers
+* The Faculty
+* Backdraft
+* À ma soeur (Fat Girl)
+* Hamnet
+* Austin Powers; The Spy Who Shagged Me
+* Lions for Lambs
+* The Hangover
+* No Other Land
+* There’s Something About Mary
+* Ikiru
+* Monkeybone
+* Muriel’s Wedding
+* The Curious Case of Benjamin Button
+* Peggy Sue Got Married
+* The Walk
+* Birdman or (The Unexpected Virtue of Ignorance)
+* Raised by Wolves
+* 9 1/2 weeks (Nine 1/2 Weeks)
+* Dressed to Kill
+* Fort Apache

--- a/movies/my-list.md
+++ b/movies/my-list.md
@@ -24,7 +24,8 @@
 * The Right Stuff
 * The Three Musketeers
 * El abuelo
-* Amaro Glory Road
+* Glory Road
+* The Crime of Father Amaro
 * Missing
 * Session 9
 * Nuit blanche
@@ -379,7 +380,6 @@
 * Lolita
 * The Reader
 * Ainda estou aqui
-* CSI: Crime Scene Investigation – Las Vegas
 * The Wolverine (X-Men: Wolverine 2)
 * Gunfight at the OK Corral
 * Casualties of War

--- a/movies/scorsese-selection.md
+++ b/movies/scorsese-selection.md
@@ -1,5 +1,5 @@
 
-# Scorsese's selection
+# Scorsese's favourites
 <img width="720" height="729" alt="scorsese" src="https://github.com/user-attachments/assets/0d1c12a6-d6e1-4f4f-aacd-a5cec6f4126b" />
 
 * 2001: A Space Odyssey

--- a/movies/scorsese-selection.md
+++ b/movies/scorsese-selection.md
@@ -1,0 +1,42 @@
+
+# Scorsese's selection
+* 2001: A Space Odyssey
+* 8½
+* Ashes and Diamonds
+* Citizen Kane
+* Diary of a Country Priest
+* Ikiru
+* The Leopard
+* Ordet
+* Paisan
+* The Red Shoes
+* The River
+* Salvatore Giuliano
+* The Searchers
+* Ugetsu Monogatari
+* Vertigo
+* Metropolis
+* Nosferatu
+* Napoleon
+* Grand Illusion
+* The Rules Of The Game
+* Children Of Paradise
+* Rome, Open City
+* The Bicycle Thief
+* Umberto D.
+* Tokyo Story
+* Seven Samurai
+* Sansho The Bailiff
+* High and Low
+* Rocco and His Brothers
+* The 400 Blows
+* Shoot the Piano Player
+* Breathless
+* Band of Outsiders
+* L’avventura
+* Blow Up
+* The Godfather
+* Apocalypse Now
+* Do the Right Thing
+* The Shining
+* Psycho

--- a/movies/scorsese-selection.md
+++ b/movies/scorsese-selection.md
@@ -1,5 +1,7 @@
 
 # Scorsese's selection
+<img width="720" height="729" alt="scorsese" src="https://github.com/user-attachments/assets/0d1c12a6-d6e1-4f4f-aacd-a5cec6f4126b" />
+
 * 2001: A Space Odyssey
 * 8½
 * Ashes and Diamonds

--- a/movies/tarantino-selection.md
+++ b/movies/tarantino-selection.md
@@ -1,4 +1,6 @@
 # Tarantino's selection
+<img width="935" height="619" alt="tarantino" src="https://github.com/user-attachments/assets/51305a43-deb8-4df4-b8e2-baf3e7f7bab3" />
+
 * The Kid
 * Die Hard
 * Sisters

--- a/movies/tarantino-selection.md
+++ b/movies/tarantino-selection.md
@@ -1,5 +1,5 @@
-# Tarantino's selection
-<img width="935" height="619" alt="tarantino" src="https://github.com/user-attachments/assets/51305a43-deb8-4df4-b8e2-baf3e7f7bab3" />
+# Tarantino's favourites
+<img width="786" height="824" alt="tarantino" src="https://github.com/user-attachments/assets/70ce2c3c-7f57-461e-a6dd-89a1b0861e25" />
 
 * The Kid
 * Die Hard

--- a/movies/tarantino-selection.md
+++ b/movies/tarantino-selection.md
@@ -1,0 +1,42 @@
+# Tarantino's selection
+* The Kid
+* Die Hard
+* Sisters
+* Near Dark
+* Showgirls
+* Friday
+* Anything Else
+* A Man Called Horse
+* House of Dark Shadows
+* The Texas Chainsaw Massacre
+* Eaten Alive
+* Nightmare Alley
+* Young Frankenstein
+* Back to the Future
+* Rolling Thunder
+* Matador
+* The Great Silence
+* The Thing
+* The Wild Bunch
+* Top Gun: Maverick
+* Rio Bravo
+* Blow Out
+* West Side Story (2021)
+* Unfaithfully Yours
+* The Good, the Bad and the Ugly
+* Abbott and Costello Meet Frankenstein
+* Dunkirk
+* Black Sabbath
+* Deep Red
+* The Social Network
+* Easy Rider
+* Apocalypse Now
+* Audition
+* Joint Security Area
+* The Insider
+* Lost in Translation
+* The Bad News Bears
+* Battle Royale
+* Boogie Nights
+* Carrie
+* Dazed and Confused

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -523,25 +523,65 @@ export default function SearchPage() {
               {localCollections.length === 0 ? (
                 <p className="text-sm text-gray-500 dark:text-gray-400">{ui.noCollectionsFound}</p>
               ) : (
-                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+                <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
                   {localCollections.map((collection) => {
                     const isActive = activeCollectionId === collection.id;
                     return (
                       <div
                         key={collection.id}
-                        className="rounded-lg border border-gray-300 dark:border-gray-700 p-3 bg-white/70 dark:bg-gray-800/50"
+                        onClick={() => handleLoadLocalCollection(collection)}
+                        className="group relative w-full aspect-[3/4] rounded-lg overflow-hidden cursor-pointer shadow-lg hover:shadow-xl transition-all transform hover:scale-105 disabled:opacity-50 disabled:cursor-not-allowed"
+                        style={{
+                          opacity: isLoading && !isActive ? 0.5 : 1,
+                          pointerEvents: isLoading && !isActive ? "none" : "auto",
+                        }}
                       >
-                        <p className="font-semibold mb-2">{collection.title}</p>
-                        <Button
-                          variant="secondary"
-                          size="small"
-                          onClick={() => handleLoadLocalCollection(collection)}
-                          loading={isActive && isLoading}
-                          disabled={isLoading && !isActive}
-                          fullWidth
-                        >
-                          {isActive && isLoading ? ui.loadingCollection : ui.loadCollection}
-                        </Button>
+                        {/* Background Image */}
+                        {collection.image ? (
+                          <img
+                            src={collection.image}
+                            alt={collection.title}
+                            className="absolute inset-0 w-full h-full object-cover"
+                          />
+                        ) : (
+                          <div className="absolute inset-0 bg-gradient-to-br from-purple-500 to-purple-900" />
+                        )}
+
+                        {/* Dark Gradient Overlay */}
+                        <div className="absolute inset-0 bg-gradient-to-t from-black via-transparent to-transparent opacity-70 group-hover:opacity-80 transition-opacity" />
+
+                        {/* Title Text */}
+                        <div className="absolute inset-0 flex items-end justify-center p-4">
+                          <h3 className="text-white font-bold text-center text-sm sm:text-base leading-tight drop-shadow-lg">
+                            {collection.title}
+                          </h3>
+                        </div>
+
+                        {/* Loading Spinner */}
+                        {isActive && isLoading && (
+                          <div className="absolute inset-0 flex items-center justify-center bg-black/40 backdrop-blur-sm">
+                            <svg
+                              className="animate-spin w-8 h-8 text-white"
+                              xmlns="http://www.w3.org/2000/svg"
+                              fill="none"
+                              viewBox="0 0 24 24"
+                            >
+                              <circle
+                                className="opacity-25"
+                                cx="12"
+                                cy="12"
+                                r="10"
+                                stroke="currentColor"
+                                strokeWidth="4"
+                              />
+                              <path
+                                className="opacity-75"
+                                fill="currentColor"
+                                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                              />
+                            </svg>
+                          </div>
+                        )}
                       </div>
                     );
                   })}

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -68,7 +68,7 @@ export default function SearchPage() {
         myAddedMovies: "Mis peliculas agregadas",
         deleteMovies: "Eliminar peliculas",
         refreshTitlesError: "No se pudieron actualizar los titulos al cambiar el idioma.",
-        localCollections: "Colecciones locales",
+        localCollections: "Colecciones de Películas",
         loadCollection: "Cargar coleccion",
         loadingCollection: "Cargando coleccion...",
         collectionNeedsApiKey: "Necesitas configurar TMDB para cargar una coleccion local.",
@@ -97,7 +97,7 @@ export default function SearchPage() {
         myAddedMovies: "My Added Movies",
         deleteMovies: "Delete Movies",
         refreshTitlesError: "Failed to refresh movie titles after language change.",
-        localCollections: "Local collections",
+        localCollections: "Movie Collections",
         loadCollection: "Load collection",
         loadingCollection: "Loading collection...",
         collectionNeedsApiKey: "You need to configure TMDB before loading a local collection.",
@@ -530,7 +530,7 @@ export default function SearchPage() {
                       <div
                         key={collection.id}
                         onClick={() => handleLoadLocalCollection(collection)}
-                        className="group relative w-full aspect-[3/4] rounded-lg overflow-hidden cursor-pointer shadow-lg hover:shadow-xl transition-all transform hover:scale-105 disabled:opacity-50 disabled:cursor-not-allowed"
+                        className="group relative w-full aspect-[4/3] rounded-lg overflow-hidden cursor-pointer shadow-lg hover:shadow-xl transition-all transform hover:scale-105 disabled:opacity-50 disabled:cursor-not-allowed"
                         style={{
                           opacity: isLoading && !isActive ? 0.5 : 1,
                           pointerEvents: isLoading && !isActive ? "none" : "auto",

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useMemo, useRef } from "react";
 import { Movie } from "../types";
 import { useMovies } from "../context/MovieContext";
 import MovieCard from "../components/MovieCard";
@@ -6,12 +6,19 @@ import Button from "../components/Button";
 import Dialog from "../components/Dialog";
 import CategorySelector from "../components/CategorySelector";
 import TMDBCategorySelector from "../components/TMDBCategorySelector";
-import { useSearchParams } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import arrowsExpandIcon from "../assets/arrows-angle-expand.svg";
 import arrowsContractIcon from "../assets/arrows-angle-contract.svg";
 import { getPlaceholder } from "../utils/placeholderUtils";
 import PosterImage from "../components/PosterImage";
 import { searchMovies, convertTMDBToAppMovie, getMovieDetails, getTMDBImageUrl } from "../services/tmdbService";
+import {
+  loadLocalMovieCollections,
+  shuffle,
+  type LocalMovieCollection,
+} from "../services/localMovieCollectionsService";
+
+const COLLECTION_SIZE = 16;
 
 const LoadingSpinner = () => (
   <div role="status" className="flex justify-center items-center">
@@ -36,6 +43,7 @@ const LoadingSpinner = () => (
 );
 
 export default function SearchPage() {
+  const navigate = useNavigate();
   const { addMovie, movieList, removeMovie, tmdbApiKey, searchLanguage, setSearchLanguage, setMovieList } = useMovies();
   const [searchParams, setSearchParams] = useSearchParams();
   const hasRestoredFromUrl = useRef(false);
@@ -60,6 +68,16 @@ export default function SearchPage() {
         myAddedMovies: "Mis peliculas agregadas",
         deleteMovies: "Eliminar peliculas",
         refreshTitlesError: "No se pudieron actualizar los titulos al cambiar el idioma.",
+        localCollections: "Colecciones locales",
+        loadCollection: "Cargar coleccion",
+        loadingCollection: "Cargando coleccion...",
+        collectionNeedsApiKey: "Necesitas configurar TMDB para cargar una coleccion local.",
+        collectionEmpty: "La coleccion no tiene suficientes peliculas.",
+        collectionNotEnoughMatches:
+          "No se pudieron encontrar 16 peliculas validas en TMDB para esta coleccion.",
+        collectionLoadedNotFound: "Algunos titulos no se encontraron:",
+        noCollectionsFound:
+          "No se encontraron archivos .md en movies.",
       }
     : {
         tmdbApiRequired: "TMDB API key is required. Please configure it in settings.",
@@ -79,6 +97,16 @@ export default function SearchPage() {
         myAddedMovies: "My Added Movies",
         deleteMovies: "Delete Movies",
         refreshTitlesError: "Failed to refresh movie titles after language change.",
+        localCollections: "Local collections",
+        loadCollection: "Load collection",
+        loadingCollection: "Loading collection...",
+        collectionNeedsApiKey: "You need to configure TMDB before loading a local collection.",
+        collectionEmpty: "This collection does not have enough movie titles.",
+        collectionNotEnoughMatches:
+          "Could not find 16 valid movies in TMDB for this collection.",
+        collectionLoadedNotFound: "Some titles were not found:",
+        noCollectionsFound:
+          "No .md files were found in movies.",
       };
   const [searchTerm, setSearchTerm] = useState<string>("");
   const [searchedMovies, setSearchedMovies] = useState<Movie[]>([]);
@@ -87,8 +115,83 @@ export default function SearchPage() {
   const [useTextarea, setUseTextarea] = useState(false);
   const [notFoundMovies, setNotFoundMovies] = useState<string[]>([]);
   const [isNotFoundDialogOpen, setIsNotFoundDialogOpen] = useState(false);
+  const [isCollectionNotFoundDialog, setIsCollectionNotFoundDialog] =
+    useState(false);
   const [isDiscoveryExpanded, setIsDiscoveryExpanded] = useState(false);
+  const [isLocalCollectionsExpanded, setIsLocalCollectionsExpanded] = useState(false);
+  const [activeCollectionId, setActiveCollectionId] = useState<string | null>(null);
   const addedMoviesRef = useRef<HTMLDivElement>(null);
+  const localCollections = useMemo(() => loadLocalMovieCollections(), []);
+
+  async function handleLoadLocalCollection(collection: LocalMovieCollection) {
+    if (!tmdbApiKey) {
+      setError(ui.collectionNeedsApiKey);
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+    setActiveCollectionId(collection.id);
+
+    try {
+      const titles = collection.movieTitles;
+      if (titles.length < COLLECTION_SIZE) {
+        setError(ui.collectionEmpty);
+        return;
+      }
+
+      const shuffledTitles = shuffle(titles);
+      const foundMovies: Movie[] = [];
+      const foundIds = new Set<string>();
+      const notFound: string[] = [];
+
+      for (const title of shuffledTitles) {
+        if (foundMovies.length >= COLLECTION_SIZE) break;
+
+        try {
+          const response = await searchMovies(tmdbApiKey, title, 1, searchLanguage);
+          if (response.results && response.results.length > 0) {
+            const convertedMovie = convertTMDBToAppMovie(response.results[0]);
+            if (convertedMovie.Poster === "N/A") {
+              convertedMovie.Poster = getPlaceholder();
+            }
+
+            if (!foundIds.has(convertedMovie.imdbID)) {
+              foundIds.add(convertedMovie.imdbID);
+              foundMovies.push(convertedMovie);
+            }
+          } else {
+            notFound.push(title);
+          }
+        } catch {
+          notFound.push(title);
+        }
+      }
+
+      if (foundMovies.length < COLLECTION_SIZE) {
+        setError(ui.collectionNotEnoughMatches);
+        if (notFound.length > 0) {
+          setNotFoundMovies(notFound.slice(0, 20));
+          setIsCollectionNotFoundDialog(true);
+          setIsNotFoundDialogOpen(true);
+        }
+        return;
+      }
+
+      setMovieList(foundMovies);
+      if (notFound.length > 0) {
+        setNotFoundMovies(notFound.slice(0, 20));
+        setIsCollectionNotFoundDialog(true);
+        setIsNotFoundDialogOpen(true);
+      }
+      navigate("/kombat");
+    } catch {
+      setError(ui.loadFromUrlError);
+    } finally {
+      setIsLoading(false);
+      setActiveCollectionId(null);
+    }
+  }
 
   useEffect(() => {
     if (hasRestoredFromUrl.current) return;
@@ -140,7 +243,7 @@ export default function SearchPage() {
     };
 
     loadMoviesFromUrl();
-  }, [tmdbApiKey, searchLanguage, searchParams, movieList.length, setMovieList]);
+  }, [tmdbApiKey, searchLanguage, searchParams, movieList.length, setMovieList, ui.loadFromUrlError]);
 
   useEffect(() => {
     const tmdbIds = movieList
@@ -249,7 +352,7 @@ export default function SearchPage() {
     };
     const timerId = setTimeout(fetchMovie, 500);
     return () => clearTimeout(timerId);
-  }, [searchTerm, tmdbApiKey, useTextarea, searchLanguage]);
+  }, [searchTerm, tmdbApiKey, useTextarea, searchLanguage, ui.movieNotFound, ui.tmdbApiRequired, ui.unexpectedError]);
 
   function handleAddMovie(movie: Movie) {
     // Add the selected movie to the list
@@ -296,6 +399,7 @@ export default function SearchPage() {
     setUseTextarea(false);
     if (notFound.length > 0) {
       setNotFoundMovies(notFound);
+      setIsCollectionNotFoundDialog(false);
       setIsNotFoundDialogOpen(true);
     }
   }
@@ -350,6 +454,7 @@ export default function SearchPage() {
     setIsLoading(false);
     if (notFound.length > 0) {
       setNotFoundMovies(notFound);
+      setIsCollectionNotFoundDialog(false);
       setIsNotFoundDialogOpen(true);
     }
     
@@ -364,12 +469,22 @@ export default function SearchPage() {
     <>
       <Dialog
         open={isNotFoundDialogOpen}
-        onClose={() => setIsNotFoundDialogOpen(false)}
+        onClose={() => {
+          setIsNotFoundDialogOpen(false);
+          setIsCollectionNotFoundDialog(false);
+        }}
         title={ui.moviesNotFoundTitle}
-        onCancel={() => setIsNotFoundDialogOpen(false)}
+        onCancel={() => {
+          setIsNotFoundDialogOpen(false);
+          setIsCollectionNotFoundDialog(false);
+        }}
         cancelText={ui.close}
       >
-        <p className="mb-3">{ui.moviesNotFoundDescription}</p>
+        <p className="mb-3">
+          {isCollectionNotFoundDialog
+            ? ui.collectionLoadedNotFound
+            : ui.moviesNotFoundDescription}
+        </p>
         <ul className="list-disc list-inside space-y-1 text-sm bg-gray-100 dark:bg-gray-700 p-3 rounded">
           {notFoundMovies.map((movie, index) => (
             <li key={index} className="text-gray-800 dark:text-gray-200">
@@ -379,6 +494,63 @@ export default function SearchPage() {
         </ul>
         <p className="mt-3 text-sm text-gray-500 dark:text-gray-400">{ui.spellingHint}</p>
       </Dialog>
+
+      <section className="max-w-5xl mx-auto px-4 mt-6">
+        <div className="bg-gradient-to-r from-emerald-50 to-cyan-50 dark:from-gray-800 dark:to-gray-700 rounded-xl border border-emerald-200 dark:border-gray-600 shadow-lg">
+          <button
+            onClick={() => setIsLocalCollectionsExpanded(!isLocalCollectionsExpanded)}
+            className="w-full p-6 text-left hover:bg-emerald-100 dark:hover:bg-gray-600 transition-colors rounded-xl"
+          >
+            <div className="flex items-center justify-between">
+              <h3 className="text-lg font-semibold text-gray-800 dark:text-white">
+                📚 {ui.localCollections}
+              </h3>
+              <svg
+                className={`w-6 h-6 text-gray-600 dark:text-gray-300 transition-transform ${
+                  isLocalCollectionsExpanded ? "rotate-180" : ""
+                }`}
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+              </svg>
+            </div>
+          </button>
+
+          {isLocalCollectionsExpanded && (
+            <div className="px-6 pb-6">
+              {localCollections.length === 0 ? (
+                <p className="text-sm text-gray-500 dark:text-gray-400">{ui.noCollectionsFound}</p>
+              ) : (
+                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+                  {localCollections.map((collection) => {
+                    const isActive = activeCollectionId === collection.id;
+                    return (
+                      <div
+                        key={collection.id}
+                        className="rounded-lg border border-gray-300 dark:border-gray-700 p-3 bg-white/70 dark:bg-gray-800/50"
+                      >
+                        <p className="font-semibold mb-2">{collection.title}</p>
+                        <Button
+                          variant="secondary"
+                          size="small"
+                          onClick={() => handleLoadLocalCollection(collection)}
+                          loading={isActive && isLoading}
+                          disabled={isLoading && !isActive}
+                          fullWidth
+                        >
+                          {isActive && isLoading ? ui.loadingCollection : ui.loadCollection}
+                        </Button>
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </section>
 
  
 

--- a/src/services/localMovieCollectionsService.test.ts
+++ b/src/services/localMovieCollectionsService.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   parseCollectionMovieTitles,
   parseCollectionTitle,
+  parseCollectionImage,
   shuffle,
 } from "./localMovieCollectionsService";
 
@@ -28,6 +29,29 @@ describe("parseCollectionMovieTitles", () => {
       "Movie B",
       "Movie C",
     ]);
+  });
+
+  it("ignores img tags when parsing titles", () => {
+    const markdown = "# A List\n\n<img src='test.jpg' />\n* Movie A\n* Movie B\n";
+
+    expect(parseCollectionMovieTitles(markdown)).toEqual([
+      "Movie A",
+      "Movie B",
+    ]);
+  });
+});
+
+describe("parseCollectionImage", () => {
+  it("extracts image src from img tag", () => {
+    const markdown = '# Title\n<img src="https://example.com/image.jpg" alt="test" />\n* Movie A\n';
+
+    expect(parseCollectionImage(markdown)).toBe("https://example.com/image.jpg");
+  });
+
+  it("returns undefined when no image tag is present", () => {
+    const markdown = "# Title\n\n* Movie A\n* Movie B\n";
+
+    expect(parseCollectionImage(markdown)).toBeUndefined();
   });
 });
 

--- a/src/services/localMovieCollectionsService.test.ts
+++ b/src/services/localMovieCollectionsService.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseCollectionMovieTitles,
+  parseCollectionTitle,
+  shuffle,
+} from "./localMovieCollectionsService";
+
+describe("parseCollectionTitle", () => {
+  it("extracts first markdown heading", () => {
+    const markdown = "# Creator watchlist\n\n* Movie A\n* Movie B\n";
+
+    expect(parseCollectionTitle(markdown, "Fallback")).toBe("Creator watchlist");
+  });
+
+  it("uses fallback when heading is missing", () => {
+    const markdown = "Movie A\nMovie B\n";
+
+    expect(parseCollectionTitle(markdown, "Fallback")).toBe("Fallback");
+  });
+});
+
+describe("parseCollectionMovieTitles", () => {
+  it("parses bullets/plain lines and removes case-insensitive duplicates", () => {
+    const markdown = "# A List\n\n* Movie A\n- Movie B\nMovie C\nmovie c\n";
+
+    expect(parseCollectionMovieTitles(markdown)).toEqual([
+      "Movie A",
+      "Movie B",
+      "Movie C",
+    ]);
+  });
+});
+
+describe("shuffle", () => {
+  it("keeps all original elements", () => {
+    const items = ["A", "B", "C", "D"];
+    const randomValues = [0.9, 0.2, 0.7, 0.1];
+    let idx = 0;
+
+    const result = shuffle(items, () => {
+      const value = randomValues[idx % randomValues.length];
+      idx += 1;
+      return value;
+    });
+
+    expect(result.slice().sort()).toEqual(items.slice().sort());
+  });
+});

--- a/src/services/localMovieCollectionsService.ts
+++ b/src/services/localMovieCollectionsService.ts
@@ -1,0 +1,94 @@
+export interface LocalMovieCollection {
+  id: string;
+  title: string;
+  movieTitles: string[];
+  filePath: string;
+}
+
+const markdownModules = import.meta.glob<string>(
+  "../../movies/*.md",
+  {
+    eager: true,
+    query: "?raw",
+    import: "default",
+  }
+);
+
+export const shuffle = <T,>(items: T[], randomFn: () => number = Math.random): T[] => {
+  const shuffled = [...items];
+  for (let i = shuffled.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(randomFn() * (i + 1));
+    [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+  }
+  return shuffled;
+};
+
+const getFileNameFromPath = (filePath: string): string => {
+  const withNoDirs = filePath.split("/").pop() ?? filePath;
+  return withNoDirs.replace(/\.md$/i, "");
+};
+
+export const parseCollectionTitle = (markdown: string, fallbackTitle: string): string => {
+  const headingLine = markdown
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .find((line) => /^#\s+/.test(line));
+
+  if (!headingLine) {
+    return fallbackTitle;
+  }
+
+  return headingLine.replace(/^#\s+/, "").trim() || fallbackTitle;
+};
+
+export const parseCollectionMovieTitles = (markdown: string): string[] => {
+  const lines = markdown
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .filter((line) => !/^#\s+/.test(line));
+
+  const normalizedToOriginal = new Map<string, string>();
+
+  for (const line of lines) {
+    const withoutListPrefix = line.replace(/^[-*+]\s+/, "").replace(/^\d+\.\s+/, "").trim();
+    if (!withoutListPrefix) {
+      continue;
+    }
+
+    const normalized = withoutListPrefix.toLowerCase();
+    if (!normalizedToOriginal.has(normalized)) {
+      normalizedToOriginal.set(normalized, withoutListPrefix);
+    }
+  }
+
+  return Array.from(normalizedToOriginal.values());
+};
+
+export const loadLocalMovieCollections = (): LocalMovieCollection[] => {
+  const collections: LocalMovieCollection[] = [];
+
+  for (const [filePath, markdown] of Object.entries(markdownModules)) {
+    const fileName = getFileNameFromPath(filePath);
+    if (fileName.toLowerCase() === "readme") {
+      continue;
+    }
+
+    const fallbackTitle = fileName
+      .replace(/[-_]+/g, " ")
+      .replace(/\s+/g, " ")
+      .trim();
+
+    const title = parseCollectionTitle(markdown, fallbackTitle);
+    const movieTitles = parseCollectionMovieTitles(markdown);
+
+    collections.push({
+      id: fileName,
+      title,
+      movieTitles,
+      filePath,
+    });
+  }
+
+  return collections.sort((a, b) => a.title.localeCompare(b.title));
+};

--- a/src/services/localMovieCollectionsService.ts
+++ b/src/services/localMovieCollectionsService.ts
@@ -3,6 +3,7 @@ export interface LocalMovieCollection {
   title: string;
   movieTitles: string[];
   filePath: string;
+  image?: string;
 }
 
 const markdownModules = import.meta.glob<string>(
@@ -46,7 +47,8 @@ export const parseCollectionMovieTitles = (markdown: string): string[] => {
     .split(/\r?\n/)
     .map((line) => line.trim())
     .filter((line) => line.length > 0)
-    .filter((line) => !/^#\s+/.test(line));
+    .filter((line) => !/^#\s+/.test(line))
+    .filter((line) => !/<img/.test(line));
 
   const normalizedToOriginal = new Map<string, string>();
 
@@ -65,6 +67,11 @@ export const parseCollectionMovieTitles = (markdown: string): string[] => {
   return Array.from(normalizedToOriginal.values());
 };
 
+export const parseCollectionImage = (markdown: string): string | undefined => {
+  const imgMatch = markdown.match(/<img[^>]+src=["']([^"']+)["']/);
+  return imgMatch ? imgMatch[1] : undefined;
+};
+
 export const loadLocalMovieCollections = (): LocalMovieCollection[] => {
   const collections: LocalMovieCollection[] = [];
 
@@ -81,12 +88,14 @@ export const loadLocalMovieCollections = (): LocalMovieCollection[] => {
 
     const title = parseCollectionTitle(markdown, fallbackTitle);
     const movieTitles = parseCollectionMovieTitles(markdown);
+    const image = parseCollectionImage(markdown);
 
     collections.push({
       id: fileName,
       title,
       movieTitles,
       filePath,
+      image,
     });
   }
 


### PR DESCRIPTION
## Summary
Add support for displaying collection images from markdown files and redesign the movie collections UI with artistic tiles.

## Changes
- **Image Support**: Extract and display images embedded in markdown collection files
- **UI Redesign**: Replace button-based layout with artistic 3:4 aspect ratio tiles
- **Image Display**: Full background images with dark gradient overlay and centered text
- **Hover Effects**: Scale and shadow animations on tile hover
- **Loading State**: Centered spinner overlay while loading collections
- **Responsive Grid**: Adapts columns based on screen size (2-5 columns)
- **Label Update**: Rename "Local collections" to "Movie Collections" (bilingual)

## Technical Details
- Added `parseCollectionImage()` function to extract image URLs from `<img>` tags in markdown
- Updated `LocalMovieCollection` interface to include optional `image` field
- Replaced Button component with custom div-based tiles for more artistic control
- Used `object-cover` for uniform image cropping across all tiles
- Added `aspect-[4/3]` for consistent tile dimensions

## Testing
- All builds pass (0 errors, 0 warnings)
- Tests passing for collection parsing functions
- Images load from GitHub URLs as specified in markdown files