### PR TITLE
Add TMDB links in bracket and winner provider availability

### DIFF
--- a/src/components/Kombat/BracketVisualization.tsx
+++ b/src/components/Kombat/BracketVisualization.tsx
@@ -6,12 +6,14 @@ interface BracketVisualizationProps {
   stages: BracketMatch[][];
   currentStage: number;
   currentRound: number;
+  onMovieClick?: (option: KombatOption) => void;
 }
 
 const BracketVisualization: React.FC<BracketVisualizationProps> = ({
   stages,
   currentStage,
   currentRound,
+  onMovieClick,
 }) => {
   if (stages.length === 0) {
     return null;
@@ -19,6 +21,7 @@ const BracketVisualization: React.FC<BracketVisualizationProps> = ({
 
   const renderTeam = (option: KombatOption, isWinner: boolean, isLoser: boolean) => {
     const isPlaceholder = option.id.startsWith('tbd');
+    const isClickable = !isPlaceholder && Boolean(onMovieClick);
     
     return (
       <div className={`flex items-center justify-between py-1 border-b border-slate-600/50 last:border-b-0 ${
@@ -26,7 +29,12 @@ const BracketVisualization: React.FC<BracketVisualizationProps> = ({
       } ${isLoser ? 'opacity-60 text-slate-400' : ''} ${
         isPlaceholder ? 'opacity-40 italic text-slate-500' : 'text-slate-200'
       }`}>
-        <div className="flex items-center min-w-0" style={{ width: '140px' }}>
+        <div
+          className={`flex items-center min-w-0 ${isClickable ? 'cursor-pointer hover:text-blue-300 transition-colors' : ''}`}
+          style={{ width: '140px' }}
+          onClick={isClickable ? () => onMovieClick?.(option) : undefined}
+          title={isClickable ? option.title : undefined}
+        >
           {!isPlaceholder && (
             <img 
               src={option.poster} 

--- a/src/pages/KombatPage.tsx
+++ b/src/pages/KombatPage.tsx
@@ -9,6 +9,12 @@ import { useNavigate } from "react-router-dom";
 import Button from "../components/Button";
 import PosterImage from "../components/PosterImage";
 import BracketVisualization from "../components/Kombat/BracketVisualization";
+import {
+  getMovieProvidersForRegion,
+  getRegionByCode,
+  type WatchProvider,
+} from "../services/tmdbService";
+import { ProviderLogo } from "../components/ProviderLogo";
 
 type Fatality = "slice" | "explode" | "smash";
 const ALL_FATALITIES: Fatality[] = ["slice", "explode", "smash"];
@@ -155,7 +161,7 @@ const KombatMatchup = ({
 };
 
 export default function KombatPage() {
-  const { movieList, setMovieList, searchLanguage } = useMovies();
+  const { movieList, setMovieList, searchLanguage, tmdbApiKey, selectedRegion } = useMovies();
   const navigate = useNavigate();
   const isSpanish = searchLanguage === "es-ES";
   const ui = isSpanish
@@ -168,6 +174,8 @@ export default function KombatPage() {
         winnerTitle: "🏆 El ganador es! 🏆",
         startNewKombat: "Empezar un nuevo Kombat",
         finalBracket: "Bracket final del Kombat",
+        availableOn: "Disponible en",
+        noPlatforms: "No hay plataformas disponibles para este pais.",
         round: "Ronda",
         of: "de",
         bracket: "Bracket del Kombat",
@@ -181,6 +189,8 @@ export default function KombatPage() {
         winnerTitle: "🏆 The Winner Is! 🏆",
         startNewKombat: "Start a New Kombat",
         finalBracket: "Final Kombat Bracket",
+        availableOn: "Available on",
+        noPlatforms: "No platforms available in this country.",
         round: "Round",
         of: "of",
         bracket: "Kombat Bracket",
@@ -190,6 +200,22 @@ export default function KombatPage() {
   const [currentStage, setCurrentStage] = useState(0);
   const [currentRound, setCurrentRound] = useState(0);
   const [winner, setWinner] = useState<KombatOption | null>(null);
+  const [winnerProviders, setWinnerProviders] = useState<WatchProvider[]>([]);
+
+  const getTMDBMovieUrl = (option: KombatOption): string => {
+    if (option.id.startsWith("tmdb_")) {
+      const tmdbId = Number(option.id.slice(5));
+      if (Number.isFinite(tmdbId)) {
+        return `https://www.themoviedb.org/movie/${tmdbId}`;
+      }
+    }
+
+    return `https://www.themoviedb.org/search?query=${encodeURIComponent(option.title)}`;
+  };
+
+  const handleOpenMovieInTMDB = (option: KombatOption) => {
+    window.open(getTMDBMovieUrl(option), "_blank", "noopener,noreferrer");
+  };
 
   const shuffleMovies = <T,>(movies: T[]): T[] => {
     const shuffled = [...movies];
@@ -212,6 +238,38 @@ export default function KombatPage() {
       setCurrentRound(firstPlayableRound >= 0 ? firstPlayableRound : 0);
     }
   }, [movieList]);
+
+  useEffect(() => {
+    if (!winner || !winner.id.startsWith("tmdb_") || !tmdbApiKey) {
+      setWinnerProviders([]);
+      return;
+    }
+
+    const tmdbId = Number(winner.id.slice(5));
+    if (!Number.isFinite(tmdbId)) {
+      setWinnerProviders([]);
+      return;
+    }
+
+    let isActive = true;
+    const loadProviders = async () => {
+      try {
+        const providers = await getMovieProvidersForRegion(tmdbApiKey, tmdbId, selectedRegion);
+        if (isActive) {
+          setWinnerProviders(providers);
+        }
+      } catch {
+        if (isActive) {
+          setWinnerProviders([]);
+        }
+      }
+    };
+
+    loadProviders();
+    return () => {
+      isActive = false;
+    };
+  }, [winner, tmdbApiKey, selectedRegion]);
 
   const handleChooseWinner = (roundWinner: KombatOption) => {
     const updatedStages = [...stages];
@@ -279,6 +337,7 @@ export default function KombatPage() {
   const currentMatch = stages[currentStage]?.[currentRound];
   const totalStages = stages.length;
   const stageName = getStageName(currentStage, totalStages);
+  const regionName = getRegionByCode(selectedRegion)?.english_name || selectedRegion;
 
   return (
     <div className="container mx-auto p-4 md:p-8">
@@ -297,6 +356,41 @@ export default function KombatPage() {
               alt={winner.title}
               className="rounded-lg shadow-2xl"
             />
+            <a
+              href={getTMDBMovieUrl(winner)}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-sm text-blue-500 hover:text-blue-400 underline"
+            >
+              TMDB
+            </a>
+            <div className="w-full rounded-lg border border-gray-300 dark:border-gray-700 p-3 bg-white/70 dark:bg-gray-800/60">
+              <p className="text-sm font-semibold text-gray-800 dark:text-gray-200 mb-2">
+                {ui.availableOn} ({regionName})
+              </p>
+              {winnerProviders.length > 0 ? (
+                <div className="flex flex-wrap justify-center gap-2">
+                  {winnerProviders.map((provider) => (
+                    <div
+                      key={provider.provider_id}
+                      title={provider.provider_name}
+                      className="inline-flex items-center gap-1.5 bg-gray-100 dark:bg-gray-700 rounded-md px-2 py-1"
+                    >
+                      <ProviderLogo
+                        logoPath={provider.logo_path}
+                        providerName={provider.provider_name}
+                        className="w-5 h-5"
+                      />
+                      <span className="text-xs text-gray-700 dark:text-gray-200">
+                        {provider.provider_name}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <p className="text-sm text-gray-500 dark:text-gray-400">{ui.noPlatforms}</p>
+              )}
+            </div>
             <div className="flex justify-center mb-4">
               <Button
                 variant="success"
@@ -321,6 +415,7 @@ export default function KombatPage() {
                   stages={stages}
                   currentStage={stages.length - 1}
                   currentRound={0}
+                  onMovieClick={handleOpenMovieInTMDB}
                 />
               </div>
             </div>
@@ -354,6 +449,7 @@ export default function KombatPage() {
                     stages={stages}
                     currentStage={currentStage}
                     currentRound={currentRound}
+                    onMovieClick={handleOpenMovieInTMDB}
                   />
                 </div>
               </div>


### PR DESCRIPTION
## Summary
This PR improves the Kombat experience by linking bracket movies to TMDB and showing winner streaming availability.

## Changes
- Make movie entries in the Kombat bracket clickable and open the movie in TMDB (new tab)
- Add TMDB fallback search link when a direct TMDB id is unavailable
- Show winner availability platforms by selected country/region
- Display provider logos and names for the winner using TMDB watch providers

## Notes
- Reuses existing region selection and TMDB provider service logic
- Keeps existing tests passing (`npm test -- --run`)
